### PR TITLE
Add PMR, PGR, PLR info into database

### DIFF
--- a/deps/cystdf/__init__.py
+++ b/deps/cystdf/__init__.py
@@ -4,7 +4,7 @@
 # Author: noonchen - chennoon233@foxmail.com
 # Created Date: April 25th 2021
 # -----
-# Last Modified: Sun Jun 13 2021
+# Last Modified: Thu Aug 26 2021
 # Modified By: noonchen
 # -----
 # Copyright (c) 2021 noonchen
@@ -24,8 +24,12 @@
 
 
 
-from . import _cystdf
 import numpy as np
+try:
+    from . import _cystdf
+except ImportError as e:
+    e.msg = "cystdf module should be built before running STDF-Viewer"
+    raise
 
 __all__ = ["stdfDataRetriever", "stdfRecordAnalyzer", "stdfParser", "setByteSwap"]
 

--- a/deps/cystdf/cystdf_amalgamation_setup.py
+++ b/deps/cystdf/cystdf_amalgamation_setup.py
@@ -4,7 +4,7 @@
 # Author: noonchen - chennoon233@foxmail.com
 # Created Date: April 20th 2021
 # -----
-# Last Modified: Wed Aug 25 2021
+# Last Modified: Thu Aug 26 2021
 # Modified By: noonchen
 # -----
 # Copyright (c) 2021 noonchen
@@ -60,12 +60,12 @@ if isMac:
       # no need for link args because we used static link by specifying omp location
       # link_args.extend(['-Xpreprocessor', '-fopenmp', '-lomp'])
 else:
-      library_dirs.append(os.path.join(os.getcwd(), "vcruntime"))
       compile_args.extend(['-fopenmp'])
       link_args.extend(['-fopenmp'])
 
 # static link in windows
 if isWindows:
+      library_dirs.append(os.path.join(os.getcwd(), "vcruntime"))
       compile_args.append('-DMS_WIN64')
       link_args.extend(['-static-libgcc',
                         '-static-libstdc++',
@@ -87,4 +87,4 @@ setup(ext_modules = cythonize(Extension(
       )))
 
 # python3 cystdf_amalgamation_setup.py build_ext --inplace
-# python cystdf_amalgamation_setup.py build_ext --inplace
+# python cystdf_amalgamation_setup.py build_ext --inplace --compile=mingw32

--- a/deps/cystdf/stdf4_src/stdf4_func.c
+++ b/deps/cystdf/stdf4_src/stdf4_func.c
@@ -4,7 +4,7 @@
  * Author: noonchen - chennoon233@foxmail.com
  * Created Date: May 11th 2021
  * -----
- * Last Modified: Mon May 17 2021
+ * Last Modified: Fri Aug 27 2021
  * Modified By: noonchen
  * -----
  * Copyright (c) 2021 noonchen
@@ -582,8 +582,17 @@ void parse_PMR(void** pRec, const unsigned char* rawData, uint16_t binaryLen) {
     read_Cn(&record->CHAN_NAM, rawData, binaryLen, &pos);
     read_Cn(&record->PHY_NAM, rawData, binaryLen, &pos);
     read_Cn(&record->LOG_NAM, rawData, binaryLen, &pos);
-    read_U1(&record->HEAD_NUM, rawData, binaryLen, &pos);
-    read_U1(&record->SITE_NUM, rawData, binaryLen, &pos);
+    // default value for head & site is 1
+    if (pos < binaryLen) {
+        read_U1(&record->HEAD_NUM, rawData, binaryLen, &pos);
+    } else {
+        record->HEAD_NUM = 1;
+    }
+    if (pos < binaryLen) {
+        read_U1(&record->SITE_NUM, rawData, binaryLen, &pos);
+    } else {
+        record->SITE_NUM = 1;
+    }
 
     *pRec = record;
 }

--- a/deps/cystdf/stdf4_src/stdf4_libc.pxd
+++ b/deps/cystdf/stdf4_src/stdf4_libc.pxd
@@ -6,7 +6,7 @@
 # Author: noonchen - chennoon233@foxmail.com
 # Created Date: April 19th 2021
 # -----
-# Last Modified: Sat Jun 19 2021
+# Last Modified: Fri Aug 27 2021
 # Modified By: noonchen
 # -----
 # Copyright (c) 2021 noonchen
@@ -165,8 +165,22 @@ cdef extern from "stdf4_func.c" nogil:
         U1  HEAD_NUM
         U1  SITE_NUM
     
-    ctypedef struct PGR
-    ctypedef struct PLR
+    ctypedef struct PGR:
+        U2      GRP_INDX
+        Cn      GRP_NAM
+        U2      INDX_CNT
+        kxU2    PMR_INDX
+
+    ctypedef struct PLR:
+        U2      GRP_CNT
+        kxU2    GRP_INDX
+        kxU2    GRP_MODE
+        kxU1    GRP_RADX
+        kxCn    PGM_CHAR
+        kxCn    RTN_CHAR
+        kxCn    PGM_CHAL
+        kxCn    RTN_CHAL
+
     ctypedef struct RDR
     ctypedef struct SDR
     ctypedef struct WIR:


### PR DESCRIPTION
1. fix the uninitialized warning in compiler time.
2. fix the dut count table not being refreshed.
3. add RTN PGM count from FTR & MPR into test_info table.
4. add test pin map to store PMR indexes of FTR & MPR tests.
5. display a more intuitive error message when the user is not built `cystdf` module.

Closing #52 