### PR TITLE
Version 3.3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
         name: Download latest numpy source
         with: 
           repository: "numpy/numpy"
-          latest: true
+          tag: "v1.21.5"
           zipBall: true
           out-file-path: "downloads"
           

--- a/STDF-Viewer.py
+++ b/STDF-Viewer.py
@@ -2050,7 +2050,7 @@ class MyWindow(QtWidgets.QMainWindow):
                             s = siteL[arrIndex]
                             if not np.isnan(s):
                                 # if site number is valid, means dutIndex is in (h, s)
-                                pinNameKeys.add( (h, s) )
+                                pinNameKeys.add( (h, int(s)) )
                                 break
                 ChanNames = []
                 for hskey in pinNameKeys:

--- a/STDF-Viewer.py
+++ b/STDF-Viewer.py
@@ -80,7 +80,7 @@ from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
 # QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps, True)
 QApplication.setHighDpiScaleFactorRoundingPolicy(QtCore.Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
     
-Version = "V3.3.0"
+Version = "V3.3.1"
 isMac = platform.system() == 'Darwin'
     
 # save config path to sys

--- a/build_tools/STDF-Viewer-emptyDEB/DEBIAN/control
+++ b/build_tools/STDF-Viewer-emptyDEB/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: stdf-viewer
-Version: 3.3.0
+Version: 3.3.1
 Section: utils
 Priority: optional
 Architecture: amd64

--- a/deps/uic_stdDutData.py
+++ b/deps/uic_stdDutData.py
@@ -4,7 +4,7 @@
 # Author: noonchen - chennoon233@foxmail.com
 # Created Date: December 20th 2020
 # -----
-# Last Modified: Tue Dec 21 2021
+# Last Modified: Tue Jan 04 2022
 # Modified By: noonchen
 # -----
 # Copyright (c) 2021 noonchen
@@ -80,9 +80,9 @@ class DutDataReader(QtWidgets.QWidget):
         
         self.test_number_tuple_List = [self.parent.getTestNumTup(ele) for ele in self.parent.completeTestList]
         self.total = len(self.test_number_tuple_List)
-        dutInfo = [self.parent.dutSummaryDict[i] for i in self.selectedDutIndex]
+        dutInfo = [self.parent.getDutSummaryOfIndex(i) for i in self.selectedDutIndex]
         # get dut flag info for showing tips
-        dutFlagAsString = [dutSumList[-1].split(b"-")[-1] for dutSumList in dutInfo]
+        dutFlagAsString = [dutSumList[-1].split("-")[-1] for dutSumList in dutInfo]
         dutFlagInfo = [self.parent.dut_flag_parser(ele) for ele in dutFlagAsString]
         # test data section
         dutData = []
@@ -168,19 +168,19 @@ class dutDataDisplayer(QtWidgets.QDialog):
         # get dut pass/fail list
         statIndex = self.hh.index(self.tr("DUT Flag"))
         self.dutFlagInfo = [""] * vh_len + self.dutFlagInfo     # prepend empty tips for non-data cell
-        dutStatus = [b"P"] * vh_len + [dutInfo_perDUT[statIndex][:1] for dutInfo_perDUT in self.dutInfo]        # get first letter
+        dutStatus = ["P"] * vh_len + [dutInfo_perDUT[statIndex][:1] for dutInfo_perDUT in self.dutInfo]        # get first letter
         for col_tuple in zip(*self.dutInfo):
-            tmpCol = [b""] * vh_len + list(col_tuple)
+            tmpCol = [""] * vh_len + list(col_tuple)
             qitemCol = []
             for i, (item, flagCap, dutTip) in enumerate(zip(tmpCol, dutStatus, self.dutFlagInfo)):
-                qitem = QtGui.QStandardItem(item.decode("utf-8"))
+                qitem = QtGui.QStandardItem(item)
                 qitem.setTextAlignment(QtCore.Qt.AlignCenter)
                 qitem.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
                 if i < vh_len: qitem.setData(QtGui.QColor("#0F80FF7F"), QtCore.Qt.BackgroundRole)   # add bgcolor for non-data cell
                 # use first letter to check dut status
-                if flagCap == b"P":
+                if flagCap == "P":
                     pass
-                elif flagCap == b"F": 
+                elif flagCap == "F": 
                     qitem.setData(QtGui.QColor("#FFFFFF"), QtCore.Qt.ForegroundRole)
                     qitem.setData(QtGui.QColor("#CC0000"), QtCore.Qt.BackgroundRole)
                 else:
@@ -188,7 +188,7 @@ class dutDataDisplayer(QtWidgets.QDialog):
                     qitem.setData(QtGui.QColor("#FE7B00"), QtCore.Qt.BackgroundRole)
                 if dutTip != "":
                     qitem.setToolTip(dutTip)
-                qitemCol.append(qitem)                        
+                qitemCol.append(qitem)
             self.tmodel.appendColumn(qitemCol)
         
         for dataCol, statCol, flagInfoCol in zip(self.dutData, self.dutStat, self.testFlagInfo):


### PR DESCRIPTION
1. decode text with `cp1252` charset (compatible with `latin1`) if the default `utf-8` fails, should fix #78.
2. fix an error when hiding all sigma lines in the histogram.
3. reduce memory usage, especially for large stdf files.