### PR TITLE
feat(dut-summary): add PART_TXT column to DUT Summary table

### DIFF
--- a/STDF-Viewer.py
+++ b/STDF-Viewer.py
@@ -726,8 +726,8 @@ class MyWindow(QtWidgets.QMainWindow):
         self.tmodel_dut.setQuery(QtSql.QSqlQuery(DUT_SUMMARY_QUERY, self.db_dut))
         
         for column in range(0, header.count()):
-            if column in [2, 3, header.count()-1]:
-                # PartID, Head-Site and DUT Flag
+            if column in [2, 3, 4, header.count()-1]:
+                # PartID, Part Text, Head-Site and DUT Flag
                 # column may be too long to display
                 mode = QHeaderView.ResizeMode.ResizeToContents
             else:
@@ -741,6 +741,19 @@ class MyWindow(QtWidgets.QMainWindow):
             self.ui.dutInfoTable.hideColumn(1)
         else:
             self.ui.dutInfoTable.showColumn(1)
+        
+        # hide Part Text column (column 3) if all values are empty
+        has_part_txt = False
+        for row in range(self.tmodel_dut.rowCount()):
+            part_txt = self.tmodel_dut.data(self.tmodel_dut.index(row, 3), Qt.ItemDataRole.DisplayRole)
+            if part_txt and part_txt.strip():
+                has_part_txt = True
+                break
+        
+        if not has_part_txt:
+            self.ui.dutInfoTable.hideColumn(3)
+        else:
+            self.ui.dutInfoTable.showColumn(3)
         # # show all rows
         # while self.tmodel_dut.canFetchMore():
         #     self.tmodel_dut.fetchMore()

--- a/deps/SharedSrc.py
+++ b/deps/SharedSrc.py
@@ -287,6 +287,7 @@ DUT_SUMMARY_QUERY = '''SELECT
                             DUTIndex,
                             Dut_Info.Fid AS "File ID",
                             PartID AS "Part ID",
+                            PART_TXT AS "Part Text",
                             'Head ' || HEAD_NUM || ' - ' || 'Site ' || SITE_NUM AS "Test Head - Site",
                             TestCount AS "Tests Executed",
                             TestTime || ' ms' AS "Test Time",

--- a/deps/customizedQtClass.py
+++ b/deps/customizedQtClass.py
@@ -111,14 +111,15 @@ class DutSortFilter(QSortFilterProxyModel):
         self.dutIndexInd = 0
         self.fidColInd = 1
         self.pidColInd = 2
-        self.hsColInd = 3
-        self.tcntColInd = 4
-        self.ttimColInd = 5
-        self.hbinColInd = 6
-        self.sbinColInd = 7
-        self.widColInd = 8
-        self.xyColInd = 9
-        self.flagColInd = 10
+        self.ptxtColInd = 3
+        self.hsColInd = 4
+        self.tcntColInd = 5
+        self.ttimColInd = 6
+        self.hbinColInd = 7
+        self.sbinColInd = 8
+        self.widColInd = 9
+        self.xyColInd = 10
+        self.flagColInd = 11
         
     
     def lessThan(self, left: QModelIndex, right: QModelIndex) -> bool:

--- a/deps/rust_stdf_helper/src/database_context.rs
+++ b/deps/rust_stdf_helper/src/database_context.rs
@@ -77,6 +77,7 @@ static CREATE_TABLE_SQL: &str = "DROP TABLE IF EXISTS File_List;
                                                         TestCount INTEGER,
                                                         TestTime INTEGER,
                                                         PartID TEXT,
+                                                        PART_TXT TEXT,
                                                         HBIN INTEGER,
                                                         SBIN INTEGER,
                                                         Flag INTEGER,
@@ -226,7 +227,7 @@ static INSERT_DUT: &str = "INSERT INTO
                                 (?,?,?,?);";
 
 static UPDATE_DUT: &str = "UPDATE Dut_Info SET 
-                                TestCount=:TestCount, TestTime=:TestTime, PartID=:PartID, 
+                                TestCount=:TestCount, TestTime=:TestTime, PartID=:PartID, PART_TXT=:PART_TXT,
                                 HBIN=:HBIN_NUM, SBIN=:SBIN_NUM, Flag=:Flag, 
                                 WaferIndex=:WaferIndex, XCOORD=:XCOORD, YCOORD=:YCOORD,
                                 Supersede=:Supersede

--- a/deps/rust_stdf_helper/src/rust_functions.rs
+++ b/deps/rust_stdf_helper/src/rust_functions.rs
@@ -1422,6 +1422,7 @@ fn on_prr_rec(
         prr_rec.num_test,
         prr_rec.test_t,
         prr_rec.part_id,
+        prr_rec.part_txt,
         prr_rec.hard_bin,
         prr_rec.soft_bin,
         prr_rec.part_flg[0],


### PR DESCRIPTION
## Problem

The DUT Summary table currently displays Part ID but not the Part Text (PART_TXT) field from PRR records. While Part ID is often a short internal code, Part Text provides a descriptive human-readable name that helps identify the device under test without referring to external documentation.

## Solution

Add a new "Part Text" column to the DUT Summary table displaying the PART_TXT field from PRR records. The column appears between "Part ID" and "Test Head - Site".

Closes #168 

## Examples

- Part Text column hides automatically for STDF Files if there are no PRRs with PART_TXT defined, addresing concern outlined in https://github.com/noonchen/STDF-Viewer/issues/168#issuecomment-3433516441
<img width="1430" height="867" alt="Image" src="https://github.com/user-attachments/assets/8beb814d-307a-4605-b347-77fa770e4ef6" />

- STDF FIle DUT Summary with at least one PRR with PART_TXT attribute populated
<img width="1432" height="865" alt="image" src="https://github.com/user-attachments/assets/4977d3df-c252-46c9-a458-3dbc353575ba" />