### PR TITLE
fix: Export silently yields zero GDR/DTR rows when result fits in initial QSqlQueryModel batch (closes #177)

### DIFF
--- a/STDF-Viewer.py
+++ b/STDF-Viewer.py
@@ -1137,25 +1137,23 @@ class MyWindow(QtWidgets.QMainWindow):
     def getDatalogForReport(self):
         # this table uses sql query model
         model = self.tmodel_datalog
-        
-        # # method 1: store complete data in a list
-        # while model.canFetchMore():
-        #     model.fetchMore()
 
-        # datalog = []
-        # for row in range(model.rowCount()):
-        #     datalogRow = []
-        #     for col in range(model.columnCount()):
-        #         d = model.data(model.index(row, col), Qt.ItemDataRole.DisplayRole)
-        #         datalogRow.append(d if isinstance(d, str) else "")
-        #     datalog.append(datalogRow)
-        # return datalog
-        
-        # method 2: use generator
+        # Generator: yield whatever rows are currently in the model, then
+        # call fetchMore() and yield again, repeating until the underlying
+        # query is exhausted.
+        #
+        # The previous "while canFetchMore(): fetchMore(); yield rows..."
+        # shape silently produced an empty Export sheet whenever the entire
+        # query result fit in QSqlQueryModel's initial prefetch batch
+        # (default 256 rows). In that case canFetchMore() is already False
+        # by the time this method runs, so the outer loop never entered
+        # and zero rows were ever yielded. DTR/GDR records in a single
+        # STDF file are almost always well under 256, which is why issue
+        # #177 manifested as a blank GDR & DTR Summary sheet while the
+        # converter (DatabaseFetcher.getDTR_GDRs, which runs the SQL
+        # directly) produced the expected output.
         row = 0
-        while model.canFetchMore():
-            model.fetchMore()
-            
+        while True:
             while row < model.rowCount():
                 datalogRow = []
                 for col in range(model.columnCount()):
@@ -1163,6 +1161,9 @@ class MyWindow(QtWidgets.QMainWindow):
                     datalogRow.append(d.strip("\n") if isinstance(d, str) else str(d))
                 row += 1
                 yield datalogRow
+            if not model.canFetchMore():
+                break
+            model.fetchMore()
     
     
     def getImageBytesForReport(self, testTuple: tuple, head: int, sites: list[int], fids: list[int], tabType: tab):

--- a/STDF-Viewer.py
+++ b/STDF-Viewer.py
@@ -1137,21 +1137,23 @@ class MyWindow(QtWidgets.QMainWindow):
     def getDatalogForReport(self):
         # this table uses sql query model
         model = self.tmodel_datalog
+        
+        # # method 1: store complete data in a list
+        # while model.canFetchMore():
+        #     model.fetchMore()
 
-        # Generator: yield whatever rows are currently in the model, then
-        # call fetchMore() and yield again, repeating until the underlying
-        # query is exhausted.
-        #
-        # The previous "while canFetchMore(): fetchMore(); yield rows..."
-        # shape silently produced an empty Export sheet whenever the entire
-        # query result fit in QSqlQueryModel's initial prefetch batch
-        # (default 256 rows). In that case canFetchMore() is already False
-        # by the time this method runs, so the outer loop never entered
-        # and zero rows were ever yielded. DTR/GDR records in a single
-        # STDF file are almost always well under 256, which is why issue
-        # #177 manifested as a blank GDR & DTR Summary sheet while the
-        # converter (DatabaseFetcher.getDTR_GDRs, which runs the SQL
-        # directly) produced the expected output.
+        # datalog = []
+        # for row in range(model.rowCount()):
+        #     datalogRow = []
+        #     for col in range(model.columnCount()):
+        #         d = model.data(model.index(row, col), Qt.ItemDataRole.DisplayRole)
+        #         datalogRow.append(d if isinstance(d, str) else "")
+        #     datalog.append(datalogRow)
+        # return datalog
+        
+        # method 2: use generator
+        # Yield whatever rows are currently in the model, then call fetchMore()
+        # and yield again, repeating until the underlying query is exhausted.
         row = 0
         while True:
             while row < model.rowCount():


### PR DESCRIPTION
## Summary

`getDatalogForReport()` is a generator the Excel exporter uses to
stream GDR/DTR rows out of the `tmodel_datalog` Qt model. The
previous shape silently yielded **zero rows** whenever the entire
query result fit in `QSqlQueryModel`'s initial prefetch batch
(default 256 rows). DTR/GDR records in a typical STDF file are well
under 256, so the GDR & DTR Summary sheet always came out blank even
though the data was in the DB — exactly the symptom in #177. The
"Convert STDF to XLSX" path goes through `DatabaseFetcher.getDTR_GDRs`
which executes the SQL directly, and so was unaffected.

Closes #177.

## Root cause

```python
# previous
row = 0
while model.canFetchMore():        # <-- already False if result ≤ 256 rows
    model.fetchMore()
    while row < model.rowCount():
        ...
        yield datalogRow
```

`QSqlQueryModel` pre-populates up to 256 rows on `setQuery()`.
`canFetchMore()` returns `True` only if there are *more* rows beyond
that initial batch. So for small result sets the outer loop never
runs and the generator yields nothing.

## Change

```python
# new
row = 0
while True:
    while row < model.rowCount():
        ...
        yield datalogRow
    if not model.canFetchMore():
        break
    model.fetchMore()
```

Yield current rows first, then fetch more, repeat until exhausted.
Streaming behaviour is preserved for large result sets; the small-
result-set case now drains the rows that are already in the model.

## Verification

Reproduced and verified deterministically using a `FakeModel` that
mimics `QSqlQueryModel`'s 256-row prefetch:

```
total=   0 | old yielded=   0 [ok ] | new yielded=   0 [ok]
total=   1 | old yielded=   0 [BUG] | new yielded=   1 [ok]
total=   5 | old yielded=   0 [BUG] | new yielded=   5 [ok]
total= 100 | old yielded=   0 [BUG] | new yielded= 100 [ok]
total= 256 | old yielded=   0 [BUG] | new yielded= 256 [ok]
total= 257 | old yielded= 257 [ok ] | new yielded= 257 [ok]
total= 500 | old yielded= 500 [ok ] | new yielded= 500 [ok]
total=1000 | old yielded=1000 [ok ] | new yielded=1000 [ok]
```

(The repo has no automated test harness, so this was static
reproduction; if you have a sample STDF with DTR records that
previously reproduced #177, the same file should now produce a
populated `GDR & DTR Summary` sheet on Export.)

## Scope

`getDatalogForReport` is only called from
`stdfExporter.getTableDataFromParent` in
`deps/uic_stdExporter.py`, so the change is scoped to the Export
path. The in-GUI GDR & DTR table iterates the model directly via
`tmodel_datalog` and was not affected by the bug.